### PR TITLE
Highlight matches when using full-text search

### DIFF
--- a/src/type-ahead.js
+++ b/src/type-ahead.js
@@ -204,7 +204,8 @@ TypeAhead.prototype.getItemValue = function (item) {
  * @return {string}
  */
 TypeAhead.prototype.highlight = function (item) {
-    return this.getItemValue(item).replace(new RegExp('^(' + this.query + ')', 'ig'), function ($1, match) {
+    var regExp = new RegExp((this.fulltext ? '' : '^') + '(' + this.query + ')', 'ig');
+    return this.getItemValue(item).replace(regExp, function ($1, match) {
         return '<strong>' + match + '</strong>';
     });
 };


### PR DESCRIPTION
Only matches at the beginning are being highlighted. This pull request changes the regular expression used when the fulltext flag is enabled.
